### PR TITLE
Add detokenized bleu with sacrebleu as additional eval type

### DIFF
--- a/paired-bootstrap.py
+++ b/paired-bootstrap.py
@@ -59,7 +59,8 @@ def eval_measure(gold, sys, eval_type='acc'):
     return np.corrcoef([gold, sys])[0,1]
   elif eval_type == EVAL_TYPE_BLEU_DETOK:
     import sacrebleu
-    return sacrebleu.corpus_bleu(sys, [gold]).score
+    # make sure score is 0-based instead of 100-based
+    return sacrebleu.corpus_bleu(sys, [gold]).score / 100.
   else:
     raise NotImplementedError('Unknown eval type in eval_measure: %s' % eval_type)
 

--- a/paired-bootstrap.py
+++ b/paired-bootstrap.py
@@ -1,6 +1,7 @@
 ######################################################################
 # Compare two systems using bootstrap resampling                     #
-#  by Graham Neubig                                                  #
+#  * by Graham Neubig                                                #
+#  * minor modifications by Mathias Müller                           #
 #                                                                    #
 # See, e.g. the following paper for references                       #
 #                                                                    #
@@ -12,13 +13,25 @@
 
 import numpy as np
 
+
+EVAL_TYPE_ACC = "acc"
+EVAL_TYPE_BLEU = "bleu"
+EVAL_TYPE_BLEU_DETOK = "bleu_detok"
+EVAL_TYPE_PEARSON = "pearson"
+
+EVAL_TYPES = [EVAL_TYPE_ACC,
+              EVAL_TYPE_BLEU,
+              EVAL_TYPE_BLEU_DETOK,
+              EVAL_TYPE_PEARSON]
+
+
 def eval_preproc(data, eval_type='acc'):
   ''' Preprocess into the appropriate format for a particular evaluation type '''
   if type(data) == str:
     data = data.strip()
-    if eval_type == 'bleu':
+    if eval_type == EVAL_TYPE_BLEU:
       data = data.split()
-    elif eval_type == 'pearson':
+    elif eval_type == EVAL_TYPE_PEARSON:
       data = float(data)
   return data
 
@@ -28,21 +41,25 @@ def eval_measure(gold, sys, eval_type='acc'):
   This takes in gold labels and system outputs and evaluates their
   accuracy. It currently supports:
   * Accuracy (acc), percentage of labels that match
-  * Pearson's correlation coefficeint (pearson)
+  * Pearson's correlation coefficient (pearson)
   * BLEU score (bleu)
+  * BLEU_detok, on detokenized references and translations, with internal tokenization
 
   :param gold: the correct labels
   :param sys: the system outputs
-  :param eval_type: The type of evaluation to do (acc, pearson, bleu)
+  :param eval_type: The type of evaluation to do (acc, pearson, bleu, bleu_detok)
   '''
-  if eval_type == 'acc':
+  if eval_type == EVAL_TYPE_ACC:
     return sum([1 if g == s else 0 for g, s in zip(gold, sys)]) / float(len(gold))
-  elif eval_type == 'bleu':
+  elif eval_type == EVAL_TYPE_BLEU:
     import nltk
     gold_wrap = [[x] for x in gold]
     return nltk.translate.bleu_score.corpus_bleu(gold_wrap, sys)
-  elif eval_type == 'pearson':
+  elif eval_type == EVAL_TYPE_PEARSON:
     return np.corrcoef([gold, sys])[0,1]
+  elif eval_type == EVAL_TYPE_BLEU_DETOK:
+    import sacrebleu
+    return sacrebleu.corpus_bleu(sys, [gold]).score
   else:
     raise NotImplementedError('Unknown eval type in eval_measure: %s' % eval_type)
 
@@ -51,7 +68,7 @@ def eval_with_paired_bootstrap(gold, sys1, sys2,
                                eval_type='acc'):
   ''' Evaluate with paired boostrap
 
-  This compares two systems, performing a signifiance tests with
+  This compares two systems, performing a significance tests with
   paired bootstrap resampling to compare the accuracy of the two systems.
   
   :param gold: The correct labels
@@ -59,7 +76,7 @@ def eval_with_paired_bootstrap(gold, sys1, sys2,
   :param sys2: The output of system 2
   :param num_samples: The number of bootstrap samples to take
   :param sample_ratio: The ratio of samples to take every time
-  :param eval_type: The type of evaluation to do (acc, pearson, bleu)
+  :param eval_type: The type of evaluation to do (acc, pearson, bleu, bleu_detok)
   '''
   assert(len(gold) == len(sys1))
   assert(len(gold) == len(sys2))
@@ -117,7 +134,7 @@ if __name__ == "__main__":
   parser.add_argument('gold', help='File of the correct answers')
   parser.add_argument('sys1', help='File of the answers for system 1')
   parser.add_argument('sys2', help='File of the answers for system 2')
-  parser.add_argument('--eval_type', help='The evaluation type (acc/pearson/bleu)', type=str, default='acc')
+  parser.add_argument('--eval_type', help='The evaluation type (acc/pearson/bleu/bleu_detok)', type=str, default='acc', choices=EVAL_TYPES)
   parser.add_argument('--num_samples', help='Number of samples to use', type=int, default=10000)
   args = parser.parse_args()
   


### PR DESCRIPTION
Hi Graham,

I used your paired bootstrap script for detokenized BLEU, would you be interested to pull this addition into your repo?

Some sample outputs for comparison:

```sh
# tokenized BLEU
% python paired-bootstrap.py --num_samples 100 --eval_type bleu reference translations.system1 translations.system2
Win ratio: sys1=0.930, sys2=0.070, tie=0.930
(sys1 is superior with p value p=0.070)

sys1 mean=0.136, median=0.136, 95% confidence interval=[0.131, 0.141]
sys2 mean=0.132, median=0.133, 95% confidence interval=[0.127, 0.137]

% perl multi-bleu.perl reference < translations.system1
BLEU = 13.58, 47.8/23.6/13.3/7.6 (BP=0.738, ratio=0.767, hyp_len=40043, ref_len=52218)

perl multi-bleu.perl reference < translations.system2
BLEU = 13.29, 47.0/22.7/12.7/7.3 (BP=0.750, ratio=0.776, hyp_len=40545, ref_len=52218)

# untokenized BLEU equivalent to multi-bleu-detok
% python paired-bootstrap.py --num_samples 100 --eval_type bleu_detok reference translations.system1 translations.system2
Win ratio: sys1=0.900, sys2=0.100, tie=0.900
(sys1 is superior with p value p=0.100)

sys1 mean=0.215, median=0.215, 95% confidence interval=[0.209, 0.222]
sys2 mean=0.212, median=0.212, 95% confidence interval=[0.205, 0.221]

% perl multi-bleu-detok.perl reference < translations.system1
BLEU = 21.47, 55.6/29.8/18.9/12.6 (BP=0.857, ratio=0.866, hyp_len=46976, ref_len=54226)

% perl multi-bleu-detok.perl reference < translations.system2
BLEU = 21.13, 54.8/29.1/18.3/12.0 (BP=0.869, ratio=0.877, hyp_len=47572, ref_len=54226)
```

Regards
Mathias